### PR TITLE
Update gomod mapping for k8s.io/dynamic-resource-allocation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -144,6 +144,7 @@ replace (
 	k8s.io/controller-manager => k8s.io/controller-manager v0.26.1
 	k8s.io/cri-api => k8s.io/cri-api v0.26.1
 	k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.26.1
+	k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.26.1
 	k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.26.1
 	k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.26.1
 	k8s.io/kube-proxy => k8s.io/kube-proxy v0.26.1

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1363,6 +1363,7 @@ sigs.k8s.io/yaml
 # k8s.io/controller-manager => k8s.io/controller-manager v0.26.1
 # k8s.io/cri-api => k8s.io/cri-api v0.26.1
 # k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.26.1
+# k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.26.1
 # k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.26.1
 # k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.26.1
 # k8s.io/kube-proxy => k8s.io/kube-proxy v0.26.1


### PR DESCRIPTION
The command "go list -mod readonly -m -f {{ if not .Main }}{{ .String }}{{ end }} all" failed with: go: k8s.io/dynamic-resource-allocation@v0.0.0: reading https://cachito-athens.cachito-prod.svc/k8s.io/dynamic-resource-allocation/@v/v0.0.0.info: 404 Not Found