### PR TITLE
OCPBUGS-15253: Include ingress's namespace in ingress without class metric

### DIFF
--- a/pkg/route/ingress/metrics.go
+++ b/pkg/route/ingress/metrics.go
@@ -23,7 +23,7 @@ var (
 	ingressesWithoutClassName = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: metricIngressWithoutClassName,
 		Help: "Report the number of ingresses that do not specify ingressClassName.",
-	}, []string{"name"})
+	}, []string{"name", "namespace"})
 )
 
 func (c *Controller) Create(v *semver.Version) bool {
@@ -69,7 +69,7 @@ func (c *Controller) Collect(ch chan<- prometheus.Metric) {
 		if icName == nil || *icName == "" {
 			labelVal = 1
 		}
-		ingressesWithoutClassName.WithLabelValues(ingressInstance.Name).Set(float64(labelVal))
+		ingressesWithoutClassName.WithLabelValues(ingressInstance.Name, ingressInstance.Namespace).Set(float64(labelVal))
 	}
 
 	ingressesWithoutClassName.Collect(ch)

--- a/pkg/route/ingress/metrics_test.go
+++ b/pkg/route/ingress/metrics_test.go
@@ -58,7 +58,7 @@ func TestMetrics(t *testing.T) {
 			},
 			ingressclassLister: &ingressclassLister{},
 			routeLister:        &routeLister{},
-			expectedResponse:   "openshift_ingress_to_route_controller_ingress_without_class_name{name=\"nil-ingressclassname\"} 1",
+			expectedResponse:   "openshift_ingress_to_route_controller_ingress_without_class_name{name=\"nil-ingressclassname\",namespace=\"test\"} 1",
 		},
 		{
 			name: "Ingress with empty IngressClassName should return 1",
@@ -75,7 +75,7 @@ func TestMetrics(t *testing.T) {
 			},
 			ingressclassLister: &ingressclassLister{},
 			routeLister:        &routeLister{},
-			expectedResponse:   "openshift_ingress_to_route_controller_ingress_without_class_name{name=\"empty-ingressclassname\"} 1",
+			expectedResponse:   "openshift_ingress_to_route_controller_ingress_without_class_name{name=\"empty-ingressclassname\",namespace=\"test\"} 1",
 		},
 		{
 			name: "Ingress with empty string IngressClassName should return 1",
@@ -94,7 +94,7 @@ func TestMetrics(t *testing.T) {
 			},
 			ingressclassLister: &ingressclassLister{},
 			routeLister:        &routeLister{},
-			expectedResponse:   "openshift_ingress_to_route_controller_ingress_without_class_name{name=\"emptystring-ingressclassname\"} 1",
+			expectedResponse:   "openshift_ingress_to_route_controller_ingress_without_class_name{name=\"emptystring-ingressclassname\",namespace=\"test\"} 1",
 		},
 		{
 			name: "Ingress with set IngressClassName should return 0",
@@ -113,7 +113,7 @@ func TestMetrics(t *testing.T) {
 			},
 			ingressclassLister: &ingressclassLister{},
 			routeLister:        &routeLister{},
-			expectedResponse:   "openshift_ingress_to_route_controller_ingress_without_class_name{name=\"set-ingressclassname\"} 0",
+			expectedResponse:   "openshift_ingress_to_route_controller_ingress_without_class_name{name=\"set-ingressclassname\",namespace=\"test\"} 0",
 		},
 		{
 			name: "Route with an unmanaged Ingress owner should return 1",


### PR DESCRIPTION
OpenShift's ingress operator creates a prometheus alert based on the `openshift_ingress_to_route_controller_ingress_without_class_name` metric, and to make it clearer which ingress is missing an ingress class name, the alert message needs to include ingress's namespace. This adds the namespace as a tag on the metric, which will be used in the alert message.