### PR TITLE
OCPBUGS-30048: Fix OWNERS file to reflect the correct team

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,11 +1,22 @@
 reviewers:
-  - bparees
-  - mfojtik
-  - soltysh
-  - csrwng
-  - gabemontero
-  - adambkaplan
+  - knobunc
+  - Miciah
+  - frobware
+  - miheer
+  - candita
+  - rfredette
+  - alebedev87
+  - gcs278
 approvers:
+  - knobunc
+  - Miciah
+  - frobware
+  - miheer
+  - candita
+  - rfredette
+  - alebedev87
+  - gcs278
+emeritus_approvers:
   - bparees
   - mfojtik
   - soltysh


### PR DESCRIPTION
 Fix OWNERS file to reflect the correct team (Network Edge).  Fixes https://github.com/openshift/route-controller-manager/issues/40