### PR TITLE
WIP: Provide error report from ingress-to-route controller

### DIFF
--- a/pkg/route/ingressip/service_ingressip_controller.go
+++ b/pkg/route/ingressip/service_ingressip_controller.go
@@ -340,6 +340,13 @@ func (ic *IngressIPController) recordLocalAllocation(key, ipString string) (real
 	}
 	ic.allocationMap[ipString] = key
 	klog.V(5).Infof("Recorded allocation of ip %v for service %v", ipString, key)
+	ic.recorder.Eventf(&v1.Service{}, v1.EventTypeNormal, "IPAllocated", "Successfully allocated IP %v for service %v", ipString, key)
+
+	if err != nil {
+		klog.Errorf("Failed to allocate IP for service %v: %v", key, err)
+		ic.recorder.Eventf(&v1.Service{}, v1.EventTypeWarning, "IPAllocationFailed", "Failed to allocate IP for service %v: %v", key, err)
+		return false, err
+	}
 	return false, nil
 }
 


### PR DESCRIPTION
This PR revises adding an error report from ingress-to-route controller
As mentioned in the issue:
A route is not created and no error is logged. This enables an error to emit when  the controller rejects an ingress

