### PR TITLE
OCPBUGS-13181: ingress: Reset metrics when ingress is deleted

### DIFF
--- a/pkg/route/ingress/ingress.go
+++ b/pkg/route/ingress/ingress.go
@@ -377,6 +377,7 @@ func (c *Controller) sync(key queueKey) error {
 
 	ingress, err := c.ingressLister.Ingresses(key.namespace).Get(key.name)
 	if kerrors.IsNotFound(err) {
+		c.ResetIngressMetrics(key.namespace, key.name)
 		return nil
 	}
 	if err != nil {

--- a/pkg/route/ingress/metrics.go
+++ b/pkg/route/ingress/metrics.go
@@ -106,3 +106,12 @@ func (c *Controller) Collect(ch chan<- prometheus.Metric) {
 
 	unmanagedRoutes.Collect(ch)
 }
+
+// ResetIngressMetrics clears metrics for the specified ingress by setting its
+// series data to 0.  This is appropriate to do when an ingress object is
+// deleted to prevent stale metrics from triggering alerts.  As Collect only
+// updates metrics for ingresses that exist at the time when Collect is called,
+// it does not clear metrics for deleted routes.
+func (c *Controller) ResetIngressMetrics(namespace, ingressName string) {
+	ingressesWithoutClassName.WithLabelValues(ingressName, namespace).Set(0.0)
+}


### PR DESCRIPTION
When an ingress object is deleted, reset the gauge for that ingress object to 0 in order to prevent stale metrics from triggering alerts.