### PR TITLE
NE-2186: Propagate ingress labels to routes

### DIFF
--- a/pkg/route/ingress/ingress.go
+++ b/pkg/route/ingress/ingress.go
@@ -737,8 +737,7 @@ func routeMatchesIngress(
 		route.Spec.WildcardPolicy == wildcardPolicy &&
 		reflect.DeepEqual(route.Annotations, ingress.Annotations) &&
 		route.OwnerReferences[0].APIVersion == "networking.k8s.io/v1" &&
-		// Labels are flagged. If the propagation to labels is disabled, we don't care about them matching,
-		// otherwise we need to check it
+		// Matching labels is conditional on the 'reconcile-labels' annotation's being set to 'true'
 		(!propagateLabelsToRoute(ingress.Annotations) || reflect.DeepEqual(route.Labels, ingress.Labels))
 
 	if !match {

--- a/pkg/route/ingress/ingress.go
+++ b/pkg/route/ingress/ingress.go
@@ -425,7 +425,7 @@ func (c *Controller) sync(key queueKey) error {
 			Kind:      "Ingress",
 			Namespace: key.namespace,
 			Name:      key.name,
-		}, corev1.EventTypeNormal, "InvalidAnnotationValue", "Invalid value on annotation %q", routecontroller.PropagateIngressLabelFlag)
+		}, corev1.EventTypeNormal, "InvalidAnnotationValue", "Invalid value on annotation %q due to: %q", routecontroller.PropagateIngressLabelFlag, err)
 	}
 
 	// walk the ingress and identify whether any of the child routes need to be updated, deleted,
@@ -1017,7 +1017,7 @@ func shouldPropagateLabelsToRoute(annotations map[string]string) (bool, error) {
 		return false, nil
 	}
 
-	shouldPropagate, err := strconv.ParseBool(strings.ToLower(propagateLabelsFlag))
+	shouldPropagate, err := strconv.ParseBool(strings.TrimSpace(propagateLabelsFlag))
 	if err != nil {
 		return false, err
 	}

--- a/pkg/route/ingress/ingress_test.go
+++ b/pkg/route/ingress/ingress_test.go
@@ -1,7 +1,6 @@
 package ingress
 
 import (
-	"k8s.io/client-go/tools/record"
 	"reflect"
 	"strings"
 	"testing"
@@ -20,6 +19,7 @@ import (
 	corelisters "k8s.io/client-go/listers/core/v1"
 	networkingv1listers "k8s.io/client-go/listers/networking/v1"
 	clientgotesting "k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 
 	routev1 "github.com/openshift/api/route/v1"
@@ -1127,6 +1127,86 @@ func TestController_sync(t *testing.T) {
 			},
 		},
 		{
+			name: "create route - replicate label during creation",
+			fields: fields{
+				i: &ingressLister{Items: []*networkingv1.Ingress{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "1",
+							Namespace: "test",
+							Labels: map[string]string{
+								"something": "anything",
+							},
+						},
+						Spec: networkingv1.IngressSpec{
+							IngressClassName: &openshiftDefaultIngressClassName,
+							Rules: []networkingv1.IngressRule{
+								{
+									Host: "test.com",
+									IngressRuleValue: networkingv1.IngressRuleValue{
+										HTTP: &networkingv1.HTTPIngressRuleValue{
+											Paths: []networkingv1.HTTPIngressPath{
+												{
+													Backend: networkingv1.IngressBackend{
+														Service: &networkingv1.IngressServiceBackend{
+															Name: "service-1",
+															Port: networkingv1.ServiceBackendPort{
+																Name: "http",
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				}},
+				ic: &ingressclassLister{Items: []*networkingv1.IngressClass{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "openshift-default",
+						},
+						Spec: networkingv1.IngressClassSpec{
+							Controller: "openshift.io/ingress-to-route",
+							Parameters: &networkingv1.IngressClassParametersReference{
+								APIGroup: &operatorv1GroupVersion,
+								Kind:     "IngressController",
+								Name:     "default",
+							},
+						},
+					},
+				}},
+				r: &routeLister{},
+			},
+			args:        queueKey{namespace: "test", name: "1"},
+			wantExpects: []queueKey{{namespace: "test", name: "1"}},
+			wantRouteCreates: []*routev1.Route{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "<generated>",
+						Namespace:       "test",
+						OwnerReferences: []metav1.OwnerReference{{APIVersion: "networking.k8s.io/v1", Kind: "Ingress", Name: "1", Controller: &boolTrue}},
+						Labels: map[string]string{
+							"something": "anything",
+						},
+					},
+					Spec: routev1.RouteSpec{
+						Host: "test.com",
+						To: routev1.RouteTargetReference{
+							Kind: "Service",
+							Name: "service-1",
+						},
+						Port: &routev1.RoutePort{
+							TargetPort: intstr.FromString("http"),
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "create route - custom ingresscontroller",
 			fields: fields{
 				i: &ingressLister{Items: []*networkingv1.Ingress{
@@ -1323,6 +1403,150 @@ func TestController_sync(t *testing.T) {
 				{
 					Name:  "1-abcdef",
 					Patch: []byte(`[{"op":"replace","path":"/spec","value":{"host":"test.com","path":"/","to":{"kind":"Service","name":"service-1","weight":null},"port":{"targetPort":"http"}}},{"op":"replace","path":"/metadata/annotations","value":null},{"op":"replace","path":"/metadata/ownerReferences","value":[{"apiVersion":"networking.k8s.io/v1","kind":"Ingress","name":"1","uid":"","controller":true}]}]`),
+				},
+			},
+		},
+		{
+			name: "update route and propagate labels",
+			fields: fields{
+				i: &ingressLister{Items: []*networkingv1.Ingress{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "1",
+							Namespace: "test",
+							Annotations: map[string]string{
+								"route.openshift.io/reconcile-labels": "true",
+							},
+							Labels: map[string]string{
+								"my-label": "somevalue",
+							},
+						},
+						Spec: networkingv1.IngressSpec{
+							Rules: []networkingv1.IngressRule{
+								{
+									Host: "test.com",
+									IngressRuleValue: networkingv1.IngressRuleValue{
+										HTTP: &networkingv1.HTTPIngressRuleValue{
+											Paths: []networkingv1.HTTPIngressPath{
+												{
+													Path:     "/",
+													PathType: &pathTypePrefix,
+													Backend: networkingv1.IngressBackend{
+														Service: &networkingv1.IngressServiceBackend{
+															Name: "service-1",
+															Port: networkingv1.ServiceBackendPort{
+																Name: "http",
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				}},
+				r: &routeLister{Items: []*routev1.Route{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:            "1-abcdef",
+							Namespace:       "test",
+							OwnerReferences: []metav1.OwnerReference{{APIVersion: "networking.k8s.io/v1", Kind: "Ingress", Name: "1", Controller: &boolTrue}},
+						},
+						Spec: routev1.RouteSpec{
+							Host: "test.com",
+							Path: "/",
+							To: routev1.RouteTargetReference{
+								Kind: "Service",
+								Name: "service-1",
+							},
+							Port: &routev1.RoutePort{
+								TargetPort: intstr.FromInt(80),
+							},
+							WildcardPolicy: routev1.WildcardPolicyNone,
+						},
+					},
+				}},
+			},
+			args: queueKey{namespace: "test", name: "1"},
+			wantRoutePatches: []clientgotesting.PatchActionImpl{
+				{
+					Name:  "1-abcdef",
+					Patch: []byte(`[{"op":"replace","path":"/spec","value":{"host":"test.com","path":"/","to":{"kind":"Service","name":"service-1","weight":null},"port":{"targetPort":"http"}}},{"op":"replace","path":"/metadata/annotations","value":{"route.openshift.io/reconcile-labels":"true"}},{"op":"replace","path":"/metadata/labels","value":{"my-label":"somevalue"}},{"op":"replace","path":"/metadata/ownerReferences","value":[{"apiVersion":"networking.k8s.io/v1","kind":"Ingress","name":"1","uid":"","controller":true}]}]`),
+				},
+			},
+		},
+		{
+			name: "update route and do not propagate labels because of invalid flag value",
+			fields: fields{
+				i: &ingressLister{Items: []*networkingv1.Ingress{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "1",
+							Namespace: "test",
+							Annotations: map[string]string{
+								"route.openshift.io/reconcile-labels": "NotTrue",
+							},
+							Labels: map[string]string{
+								"my-label": "somevalue",
+							},
+						},
+						Spec: networkingv1.IngressSpec{
+							Rules: []networkingv1.IngressRule{
+								{
+									Host: "test.com",
+									IngressRuleValue: networkingv1.IngressRuleValue{
+										HTTP: &networkingv1.HTTPIngressRuleValue{
+											Paths: []networkingv1.HTTPIngressPath{
+												{
+													Path:     "/",
+													PathType: &pathTypePrefix,
+													Backend: networkingv1.IngressBackend{
+														Service: &networkingv1.IngressServiceBackend{
+															Name: "service-1",
+															Port: networkingv1.ServiceBackendPort{
+																Name: "http",
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				}},
+				r: &routeLister{Items: []*routev1.Route{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:            "1-abcdef",
+							Namespace:       "test",
+							OwnerReferences: []metav1.OwnerReference{{APIVersion: "networking.k8s.io/v1", Kind: "Ingress", Name: "1", Controller: &boolTrue}},
+						},
+						Spec: routev1.RouteSpec{
+							Host: "test.com",
+							Path: "/",
+							To: routev1.RouteTargetReference{
+								Kind: "Service",
+								Name: "service-1",
+							},
+							Port: &routev1.RoutePort{
+								TargetPort: intstr.FromInt(80),
+							},
+							WildcardPolicy: routev1.WildcardPolicyNone,
+						},
+					},
+				}},
+			},
+			args: queueKey{namespace: "test", name: "1"},
+			wantRoutePatches: []clientgotesting.PatchActionImpl{
+				{
+					Name:  "1-abcdef",
+					Patch: []byte(`[{"op":"replace","path":"/spec","value":{"host":"test.com","path":"/","to":{"kind":"Service","name":"service-1","weight":null},"port":{"targetPort":"http"}}},{"op":"replace","path":"/metadata/annotations","value":{"route.openshift.io/reconcile-labels":"NotTrue"}},{"op":"replace","path":"/metadata/ownerReferences","value":[{"apiVersion":"networking.k8s.io/v1","kind":"Ingress","name":"1","uid":"","controller":true}]}]`),
 				},
 			},
 		},

--- a/pkg/route/ingress/ingress_test.go
+++ b/pkg/route/ingress/ingress_test.go
@@ -1474,7 +1474,7 @@ func TestController_sync(t *testing.T) {
 			wantRoutePatches: []clientgotesting.PatchActionImpl{
 				{
 					Name:  "1-abcdef",
-					Patch: []byte(`[{"op":"replace","path":"/spec","value":{"host":"test.com","path":"/","to":{"kind":"Service","name":"service-1","weight":null},"port":{"targetPort":"http"}}},{"op":"replace","path":"/metadata/annotations","value":{"route.openshift.io/reconcile-labels":"true"}},{"op":"replace","path":"/metadata/labels","value":{"my-label":"somevalue"}},{"op":"replace","path":"/metadata/ownerReferences","value":[{"apiVersion":"networking.k8s.io/v1","kind":"Ingress","name":"1","uid":"","controller":true}]}]`),
+					Patch: []byte(`[{"op":"replace","path":"/spec","value":{"host":"test.com","path":"/","to":{"kind":"Service","name":"service-1","weight":null},"port":{"targetPort":"http"}}},{"op":"replace","path":"/metadata/annotations","value":{"route.openshift.io/reconcile-labels":"true"}},{"op":"replace","path":"/metadata/ownerReferences","value":[{"apiVersion":"networking.k8s.io/v1","kind":"Ingress","name":"1","uid":"","controller":true}]},{"op":"replace","path":"/metadata/labels","value":{"my-label":"somevalue"}}]`),
 				},
 			},
 		},

--- a/pkg/route/ingress/ingress_test.go
+++ b/pkg/route/ingress/ingress_test.go
@@ -1626,7 +1626,7 @@ func TestController_sync(t *testing.T) {
 					Patch: []byte(`[{"op":"replace","path":"/spec","value":{"host":"test.com","path":"/","to":{"kind":"Service","name":"service-1","weight":null},"port":{"targetPort":"http"}}},{"op":"replace","path":"/metadata/annotations","value":{"route.openshift.io/reconcile-labels":"NotTrue"}},{"op":"replace","path":"/metadata/ownerReferences","value":[{"apiVersion":"networking.k8s.io/v1","kind":"Ingress","name":"1","uid":"","controller":true}]}]`),
 				},
 			},
-			expectedEvents: []string{`Normal InvalidAnnotationValue Invalid value on annotation "route.openshift.io/reconcile-labels"`},
+			expectedEvents: []string{`Normal InvalidAnnotationValue Invalid value on annotation "route.openshift.io/reconcile-labels" due to: "strconv.ParseBool: parsing \"NotTrue\": invalid syntax"`},
 		},
 		{
 			name: "no-op",

--- a/pkg/routecontroller/wellknown.go
+++ b/pkg/routecontroller/wellknown.go
@@ -14,7 +14,11 @@ var (
 	// TerminationPolicyAnnotationKey defines what TLSTerminationType should be used
 	// on the Route being created
 	TerminationPolicyAnnotationKey = routev1.GroupName + "/termination"
-	//
+	// PropagateIngressLabelFlag defines if the labels of the Ingress resource
+	// should be used to replace the labels on the generated Route resource.
+	// In case this feature/annotation is enabled, any existing label on the
+	// underlying route resource will be replaced by the labels from the parent
+	// ingress resource
 	PropagateIngressLabelFlag = routev1.GroupName + "/reconcile-labels"
 	// IngressClassAnnotation is the legacy annotation used to define which
 	// controller/class should reconcile an ingress resource.

--- a/pkg/routecontroller/wellknown.go
+++ b/pkg/routecontroller/wellknown.go
@@ -14,6 +14,8 @@ var (
 	// TerminationPolicyAnnotationKey defines what TLSTerminationType should be used
 	// on the Route being created
 	TerminationPolicyAnnotationKey = routev1.GroupName + "/termination"
+	//
+	PropagateIngressLabelFlag = routev1.GroupName + "/reconcile-labels"
 	// IngressClassAnnotation is the legacy annotation used to define which
 	// controller/class should reconcile an ingress resource.
 	// In case of a conversion from an ingress to route, if the ingress specifies


### PR DESCRIPTION
This change adds the propagation of ingress resource labels to route resources.

This behavior is controller by the annotation route.openshift.io/reconcile-labels and once the annotation is enabled, the sync process will patch the child route resource and replace the labels on it for the same labels of the parent ingress.

In case the annotation is removed later, the old labels will be kept but no further replacement will happen.

This fix is based on https://github.com/openshift/route-controller-manager/commit/b48eb95de9652b8102d667f415a9e22c59c6aa6c but adding a flag to not enable the sync directly