### PR TITLE
OCPBUGS-63449: filter ingress namespace on UnmanagedRoutes metric

### DIFF
--- a/pkg/route/ingress/metrics.go
+++ b/pkg/route/ingress/metrics.go
@@ -84,7 +84,7 @@ func (c *Controller) Collect(ch chan<- prometheus.Metric) {
 				if err != nil || ingress == nil {
 					continue
 				}
-				if ingress.Name == owner {
+				if ingress.Name == owner && ingress.Namespace == routeInstance.Namespace {
 					managed, err := c.ingressManaged(ingress)
 					if err != nil {
 						utilruntime.HandleError(err)


### PR DESCRIPTION
Route controller triggers the UnmanagedRoutes metric whenever an unmanaged Ingress resource owns a Route resource. An ingress is considered managed when it points to an existing ingress class, and this ingress class configures spec.controller as "openshift.io/ingress-to-route" controller.

The management check was incorrectly filtering ingress resources by missing to check its namespace, so a managed ingress that owns a router would be considered unmanaged if an unmanaged ingress on another namespace shares the same name.