### PR TITLE
OCPBUGS-39598: Remove all duplicate ingress IP addresses in clearPersistedAllocation

### DIFF
--- a/pkg/route/ingressip/service_ingressip_controller.go
+++ b/pkg/route/ingressip/service_ingressip_controller.go
@@ -589,14 +589,23 @@ func (ic *IngressIPController) clearPersistedAllocation(service *v1.Service, key
 	// corresponding status exists, so update the spec first to avoid
 	// failing admission control.
 	ingressIP := service.Status.LoadBalancer.Ingress[0].IP
-	for i, ip := range service.Spec.ExternalIPs {
-		if ip == ingressIP {
-			klog.V(5).Infof("Removing ip %v from the external ips of service %v", ingressIP, key)
-			service.Spec.ExternalIPs = append(service.Spec.ExternalIPs[:i], service.Spec.ExternalIPs[i+1:]...)
-			if err := ic.persistServiceSpec(service); err != nil {
-				return err
-			}
-			break
+	// Remove every occurrence of the ingress ip from spec.ExternalIPs.
+	// The ingress ip can appear more than once if two changes for the
+	// same service are processed before the cache reflects the first
+	// persisted spec.ExternalIPs update (see OCPBUGS-39598); a single
+	// removal would leave a stale duplicate behind that the controller
+	// can no longer reclaim once the status is cleared.
+	filtered := service.Spec.ExternalIPs[:0]
+	for _, ip := range service.Spec.ExternalIPs {
+		if ip != ingressIP {
+			filtered = append(filtered, ip)
+		}
+	}
+	if len(filtered) != len(service.Spec.ExternalIPs) {
+		klog.V(5).Infof("Removing ip %v from the external ips of service %v", ingressIP, key)
+		service.Spec.ExternalIPs = filtered
+		if err := ic.persistServiceSpec(service); err != nil {
+			return err
 		}
 	}
 

--- a/pkg/route/ingressip/service_ingressip_controller_test.go
+++ b/pkg/route/ingressip/service_ingressip_controller_test.go
@@ -620,3 +620,51 @@ func TestBasicControllerFlow(t *testing.T) {
 		t.Fatalf("failed waiting for delete: %v", err)
 	}
 }
+
+// TestClearPersistedAllocationRemovesDuplicateIngressIP verifies that
+// clearPersistedAllocation removes every occurrence of the ingress IP
+// from spec.ExternalIPs, not just the first one.
+//
+// This guards against the scenario described in OCPBUGS-39598, where
+// the ingress IP can end up duplicated in spec.ExternalIPs (e.g. due
+// to a race between two enqueued changes both calling ensureExternalIP
+// before the cache reflects the previously-persisted update). If
+// clearPersistedAllocation stops at the first match, the leftover
+// duplicate remains on the Service after the user patches spec.type
+// from LoadBalancer to ClusterIP, leaving a stale external IP that
+// the controller can no longer reclaim.
+func TestClearPersistedAllocationRemovesDuplicateIngressIP(t *testing.T) {
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	c := newController(t, nil, stopCh)
+
+	c.persistenceHandler = func(client kcoreclient.ServicesGetter, service *v1.Service, targetStatus bool) error {
+		return nil
+	}
+
+	ingressIP := "172.16.0.1"
+	otherIPBefore := "172.16.1.1"
+	otherIPAfter := "172.16.1.2"
+
+	s := newService("svc", ingressIP, true)
+	// Seed the duplicated state the controller is observed to produce
+	// in OCPBUGS-39598: the same ingress IP appears twice in
+	// spec.ExternalIPs, interleaved with unrelated external IPs.
+	s.Spec.ExternalIPs = []string{otherIPBefore, ingressIP, otherIPAfter, ingressIP}
+	key := fmt.Sprintf("%s/%s", namespace, s.Name)
+
+	if err := c.clearPersistedAllocation(s, key, ""); err != nil {
+		t.Fatalf("unexpected error from clearPersistedAllocation: %v", err)
+	}
+
+	expectedExternalIPs := []string{otherIPBefore, otherIPAfter}
+	if got := s.Spec.ExternalIPs; !reflect.DeepEqual(expectedExternalIPs, got) {
+		t.Errorf("Expected ExternalIPs %v after clearing duplicated ingress IP, got %v",
+			expectedExternalIPs, got)
+	}
+
+	if ingressCount := len(s.Status.LoadBalancer.Ingress); ingressCount != 0 {
+		t.Errorf("Expected LoadBalancer ingress to be cleared, got %d entries",
+			ingressCount)
+	}
+}


### PR DESCRIPTION
When `ensureExternalIP` appends the ingress IP address, it only checks against the in-memory service it was given. If two changes for the same Service are processed before the cache reflects the previously-persisted `spec.externalIPs` update, both calls see the IP as absent and both append it, producing duplicated entries in `spec.externalIPs` (e.g. `EXTERNAL-IP: 10.253.164.60,10.253.164.60`).

The previous `clearPersistedAllocation` removed only the first matching entry and then `break`'d out of the loop, leaving any duplicate behind. When the user subsequently patched `spec.type` from `LoadBalancer` to `ClusterIP`, the leftover duplicate persisted on the Service even though the controller had freed the local allocation, so the external IP address could no longer be reclaimed.

Replace the single-removal loop with a filter that drops every occurrence of the ingress IP address from `spec.externalIPs`, and persist once if anything changed. Add `TestClearPersistedAllocationRemovesDuplicateIngressIP` to seed the duplicated state and assert that no copy of the ingress IP address remains after cleanup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where duplicate ingress IP entries were not completely removed from services; now all occurrences are properly cleaned up.
  * Ensured ingress status is correctly cleared when cleaning up IP allocations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->