### PR TITLE
OCPBUGS-87336: Updating ose-route-controller-manager-container image to be consistent with ART for 5.0

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-9-release-golang-1.25-openshift-4.22
+  tag: rhel-9-release-golang-1.26-openshift-5.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.26-openshift-5.0 AS builder
 WORKDIR /go/src/github.com/openshift/route-controller-manager
 COPY . .
 RUN make build --warn-undefined-variables
 
-FROM registry.ci.openshift.org/ocp/4.22:base-rhel9
+FROM registry.ci.openshift.org/ocp/5.0:base-rhel9
 COPY --from=builder /go/src/github.com/openshift/route-controller-manager/route-controller-manager /usr/bin/
 LABEL io.k8s.display-name="OpenShift Route Controller Manager Command" \
       io.k8s.description="OpenShift is a platform for developing, building, and deploying containerized applications." \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/route-controller-manager
 
-go 1.25.0
+go 1.26.3
 
 require (
 	github.com/blang/semver/v4 v4.0.0


### PR DESCRIPTION
Description:

Updates for OpenShift 5.0 ART alignment:

Update base image: registry.ci.openshift.org/ocp/4.22:base-rhel9 → registry.ci.openshift.org/ocp/5.0:base-rhel9
Update builder image: rhel-9-golang-1.25-openshift-4.22 → rhel-9-golang-1.26-openshift-5.0
Align go.mod: 1.25.0 → 1.26.3

Updates: https://github.com/openshift/route-controller-manager/pull/95

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build environment and runtime infrastructure to newer platform versions, improving compatibility with current system standards and enabling access to latest runtime improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->