### PR TITLE
OCPBUGS-92032: Dockerfile: Copy only build-required files in builder stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,11 @@
 FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22 AS builder
 WORKDIR /go/src/github.com/openshift/route-controller-manager
-COPY . .
+COPY Makefile ./
+COPY go.mod go.sum ./
+COPY .git/ .git/
+COPY cmd/ cmd/
+COPY pkg/ pkg/
+COPY vendor/ vendor/
 RUN make build --warn-undefined-variables
 
 FROM registry.ci.openshift.org/ocp/4.22:base-rhel9


### PR DESCRIPTION
Replace the broad "COPY . ." instruction in the builder stage with targeted COPY instructions for only the files and directories that "make build" requires.  This excludes documentation, CI configuration, and other files that are not needed for the build, reducing the amount of data copied into the builder image.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined the container build process to include only the files needed for compilation.
  * Kept the final runtime image and delivered application binary unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->