### PR TITLE
OCPBUGS-84872: fix O(n²) metrics collection in Collect()

### DIFF
--- a/pkg/route/ingress/metrics.go
+++ b/pkg/route/ingress/metrics.go
@@ -76,24 +76,30 @@ func (c *Controller) Collect(ch chan<- prometheus.Metric) {
 		return
 	}
 
+	// Cache ingressManaged results keyed by "namespace/name" to avoid
+	// redundant lister + ingressclass lookups for ingresses shared by many routes.
+	managedCache := make(map[string]bool, len(ingressInstances))
+
 	for _, routeInstance := range routeInstances {
 		labelVal := 0
-		if owner, have := hasIngressOwnerRef(routeInstance.OwnerReferences); have {
-			for _, ingressInstance := range ingressInstances {
-				ingress, err := c.ingressLister.Ingresses(ingressInstance.Namespace).Get(ingressInstance.Name)
-				if err != nil || ingress == nil {
-					continue
-				}
-				if ingress.Name == owner && ingress.Namespace == routeInstance.Namespace {
-					managed, err := c.ingressManaged(ingress)
+		if ownerName, have := hasIngressOwnerRef(routeInstance.OwnerReferences); have {
+			// Owner references are namespace-scoped, so the owning ingress
+			// is always in the same namespace as the route.
+			cacheKey := routeInstance.Namespace + "/" + ownerName
+			managed, cached := managedCache[cacheKey]
+			if !cached {
+				ingress, err := c.ingressLister.Ingresses(routeInstance.Namespace).Get(ownerName)
+				if err == nil && ingress != nil {
+					managed, err = c.ingressManaged(ingress)
 					if err != nil {
 						utilruntime.HandleError(err)
-						return
+						continue
 					}
-					if !managed {
-						labelVal = 1
-					}
+					managedCache[cacheKey] = managed
 				}
+			}
+			if !managed {
+				labelVal = 1
 			}
 		}
 		unmanagedRoutes.WithLabelValues(routeInstance.Name, routeInstance.Namespace, routeInstance.Spec.Host).Set(float64(labelVal))


### PR DESCRIPTION
Replace the nested loop over all ingresses per route with a direct lister lookup using the owner reference name. Add a managedCache to avoid redundant ingressManaged calls for ingresses shared by many routes, reducing complexity from O(routes x ingresses) to O(routes).

At 7400 routes x 7500 ingresses this caused the metrics endpoint to exceed the default 10s Prometheus scrape timeout on the leader pod.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ingress metrics collection for routes sharing the same ingress.
  * Metrics collection now continues when an individual ingress management check fails, allowing unaffected routes to be processed.
  * Improved labeling for managed and unmanaged routes.
  * Reduced duplicate processing, helping provide more consistent and efficient metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->